### PR TITLE
Adds missing next step in interface loop.

### DIFF
--- a/ssl_ros_bridge/src/core/get_ip_addresses.cpp
+++ b/ssl_ros_bridge/src/core/get_ip_addresses.cpp
@@ -35,6 +35,7 @@ std::vector<std::string> GetIpAdresses(const bool include_ipv6)
   auto iface_info_current = iface_info;
   while(iface_info_current != nullptr) {
     if(!iface_info_current->ifa_addr) {
+      iface_info_current = iface_info_current->ifa_next;
       continue;
     }
 


### PR DESCRIPTION
Fixes #6 

Discovery was hanging because the loop in `GetIpAdresses` did not move forward in the linked list if `ifa_addr` was null.

This PR adds the line to walk the linked list in that early-continue branch.