### PR TITLE
Connects multicast receiver logging to ROS

### DIFF
--- a/ssl_ros_bridge/src/core/CMakeLists.txt
+++ b/ssl_ros_bridge/src/core/CMakeLists.txt
@@ -15,4 +15,5 @@ target_link_libraries(${PROJECT_NAME}_core
   Boost::boost
   protobuf::libprotobuf
 )
+target_compile_features(${PROJECT_NAME}_core PUBLIC cxx_std_20)
 install(TARGETS ${PROJECT_NAME}_core DESTINATION lib)

--- a/ssl_ros_bridge/src/core/get_ip_addresses.cpp
+++ b/ssl_ros_bridge/src/core/get_ip_addresses.cpp
@@ -35,6 +35,7 @@ std::vector<std::string> GetIpAdresses(const bool include_ipv6)
   auto iface_info_current = iface_info;
   while(iface_info_current != nullptr) {
     if(!iface_info_current->ifa_addr) {
+      iface_info_current = iface_info_current->ifa_next;
       continue;
     }
 

--- a/ssl_ros_bridge/src/core/multicast_receiver.cpp
+++ b/ssl_ros_bridge/src/core/multicast_receiver.cpp
@@ -41,10 +41,17 @@ MulticastReceiver::MulticastReceiver(
   std::string multicast_address_string,
   uint16_t multicast_port,
   ReceiveCallback receive_callback,
-  std::string interface_address)
+  std::string interface_address,
+  LogHandler warning_handler_)
 : receive_callback_(receive_callback),
+  warning_handler_(warning_handler_),
   multicast_socket_(io_service_)
 {
+  if (warning_handler_ == nullptr) {
+    warning_handler_ = [this](const std::string & message) {
+      LogToStdCerr(message);
+    };
+  }
   const auto multicast_address = boost::asio::ip::make_address(multicast_address_string).to_v4();
   const boost::asio::ip::udp::endpoint multicast_endpoint(multicast_address, multicast_port);
   multicast_socket_.open(multicast_endpoint.protocol());
@@ -63,16 +70,25 @@ MulticastReceiver::MulticastReceiver(
         /* Ignore "address already in use" exceptions. This just indicates multiple addresses
          * assigned to the same interface.
          */
-        if(e.code().value() != EADDRINUSE) {
-          boost::rethrow_exception(boost::current_exception());
+        if(e.code().value() == EADDRINUSE) {
+          continue;
         }
+        warning_handler_(std::format(
+          "Failed to join multicast group on interface with address {}: {}",
+          address, e.what()));
       }
     }
   } else {
-    multicast_socket_.set_option(
-      boost::asio::ip::multicast::join_group(
-        multicast_address,
-        boost::asio::ip::make_address_v4(interface_address)));
+    try {
+      multicast_socket_.set_option(
+        boost::asio::ip::multicast::join_group(
+          multicast_address,
+          boost::asio::ip::make_address_v4(interface_address)));
+    } catch (const boost::system::system_error & e) {
+      warning_handler_(std::format(
+        "Failed to join multicast group on interface with address {}: {}",
+        interface_address, e.what()));
+    }
   }
   multicast_socket_.async_receive_from(
     boost::asio::buffer(buffer_), sender_endpoint_,
@@ -99,8 +115,7 @@ void MulticastReceiver::SendTo(
   const char * const data, const size_t length)
 {
   if (length >= send_buffer_.size()) {
-    std::cout << "WARNING: UDP send data length is larger than buffer" << std::endl;
-
+    warning_handler_("Cannot send data. UDP send data length is larger than buffer.");
     return;
   }
 
@@ -124,7 +139,7 @@ void MulticastReceiver::HandleMulticastReceiveFrom(
   size_t bytes_received)
 {
   if (error) {
-    std::cerr << "Receive from error: " << error.message() << std::endl;
+    warning_handler_(std::format("Failure while receiving data: {}", error.message()));
     return;
   }
 
@@ -143,8 +158,13 @@ void MulticastReceiver::HandleMulticastReceiveFrom(
 void MulticastReceiver::HandleUDPSendTo(const boost::system::error_code & error, size_t)
 {
   if (error) {
-    std::cerr << "Error sending UDP data: " << error.message() << std::endl;
+    warning_handler_(std::format("Failure while sending UDP data: {}", error.message()));
   }
+}
+
+void MulticastReceiver::LogToStdCerr(const std::string & message)
+{
+  std::cerr << "WARNING: " << message << std::endl;
 }
 
 }  // namespace ssl_ros_bridge::core

--- a/ssl_ros_bridge/src/core/multicast_receiver.cpp
+++ b/ssl_ros_bridge/src/core/multicast_receiver.cpp
@@ -42,15 +42,15 @@ MulticastReceiver::MulticastReceiver(
   uint16_t multicast_port,
   ReceiveCallback receive_callback,
   std::string interface_address,
-  LogHandler warning_handler_)
+  LogHandler warning_handler)
 : receive_callback_(receive_callback),
-  warning_handler_(warning_handler_),
+  warning_handler_(warning_handler),
   multicast_socket_(io_service_)
 {
   if (warning_handler_ == nullptr) {
     warning_handler_ = [this](const std::string & message) {
-      LogToStdCerr(message);
-    };
+        LogToStdCerr(message);
+      };
   }
   const auto multicast_address = boost::asio::ip::make_address(multicast_address_string).to_v4();
   const boost::asio::ip::udp::endpoint multicast_endpoint(multicast_address, multicast_port);

--- a/ssl_ros_bridge/src/core/multicast_receiver.hpp
+++ b/ssl_ros_bridge/src/core/multicast_receiver.hpp
@@ -21,6 +21,7 @@
 #ifndef CORE__MULTICAST_RECEIVER_HPP_
 #define CORE__MULTICAST_RECEIVER_HPP_
 
+#include <format>
 #include <functional>
 #include <string>
 
@@ -41,11 +42,15 @@ public:
     std::function<void (const std::string & sender_address, const uint16_t sender_port,
       uint8_t * data, size_t data_length)>;
 
+  using LogHandler = 
+    std::function<void (const std::string & message)>;
+
   MulticastReceiver(
     std::string multicast_ip_address,
     uint16_t multicast_port,
     ReceiveCallback receive_callback,
-    std::string interface_address = "");
+    std::string interface_address = "",
+    LogHandler warning_handler_ = nullptr);
 
   ~MulticastReceiver();
 
@@ -55,6 +60,7 @@ public:
 
 private:
   ReceiveCallback receive_callback_;
+  LogHandler warning_handler_;
   boost::asio::io_service io_service_;
   boost::asio::ip::udp::socket multicast_socket_;
   boost::asio::ip::udp::endpoint sender_endpoint_;
@@ -67,6 +73,8 @@ private:
   void HandleUDPSendTo(const boost::system::error_code & error, size_t bytes_sent);
 
   void JoinMulticastGroupOnAllV4Interfaces(const boost::asio::ip::address & multicast_address);
+
+  void LogToStdCerr(const std::string & message);
 };
 
 }  // namespace ssl_ros_bridge::core

--- a/ssl_ros_bridge/src/core/multicast_receiver.hpp
+++ b/ssl_ros_bridge/src/core/multicast_receiver.hpp
@@ -42,7 +42,7 @@ public:
     std::function<void (const std::string & sender_address, const uint16_t sender_port,
       uint8_t * data, size_t data_length)>;
 
-  using LogHandler = 
+  using LogHandler =
     std::function<void (const std::string & message)>;
 
   MulticastReceiver(
@@ -50,7 +50,7 @@ public:
     uint16_t multicast_port,
     ReceiveCallback receive_callback,
     std::string interface_address = "",
-    LogHandler warning_handler_ = nullptr);
+    LogHandler warning_handler = nullptr);
 
   ~MulticastReceiver();
 

--- a/ssl_ros_bridge/src/game_controller_bridge/gc_multicast_bridge_node.cpp
+++ b/ssl_ros_bridge/src/game_controller_bridge/gc_multicast_bridge_node.cpp
@@ -63,7 +63,10 @@ public:
       multicast_port,
         std::bind(&GCMulticastBridgeNode::PublishMulticastMessage, this, std::placeholders::_1,
         std::placeholders::_3, std::placeholders::_4),
-      declare_parameter<std::string>("net_interface_address", ""));
+      declare_parameter<std::string>("net_interface_address", ""),
+      [this](const std::string & message) {
+        RCLCPP_WARN(get_logger(), "%s", message.c_str());
+      });
   }
 
 private:

--- a/ssl_ros_bridge/src/vision_bridge/ssl_vision_bridge_node.cpp
+++ b/ssl_ros_bridge/src/vision_bridge/ssl_vision_bridge_node.cpp
@@ -46,7 +46,10 @@ public:
       declare_parameter<int>("ssl_vision_port", 10020),
       std::bind(&SSLVisionBridgeNode::multicastCallback, this, std::placeholders::_3,
       std::placeholders::_4),
-      declare_parameter<std::string>("net_interface_address", ""))
+      declare_parameter<std::string>("net_interface_address", ""),
+      [this](const std::string & message) {
+        RCLCPP_WARN(get_logger(), "%s", message.c_str());
+      })
   {
     SET_ROS_PROTOBUF_LOG_HANDLER("ssl_vision_bridge.protobuf");
   }


### PR DESCRIPTION
This PR improves log handling in `MulticastReceiver` to support connecting it to the ROS logging system.
Error handling in `MulticastReceiver` is also adjusted to avoid crashing the process when joining a multicast group on an interface fails. It now logs the error and continues running. In many scenarios, this causes no problem for the user. In cases where it is an actual problem, the most likely consequence is simply not receiving multicast packets.

This change set overlaps with #7 and should be reviewed after that is merged.